### PR TITLE
ios: fix dialog ios

### DIFF
--- a/frontends/web/src/components/dialog/dialog.module.css
+++ b/frontends/web/src/components/dialog/dialog.module.css
@@ -6,7 +6,8 @@
     position: fixed;
     bottom: 0;
     left: 0;
-    height: 100%;
+    height: 100vh;
+    max-height: -webkit-fill-available;
     width: 100%;
     background: transparent;
     z-index: 4010;
@@ -215,12 +216,15 @@
         padding: 0;
     }
 
+    .overlay {
+        align-items: stretch;
+        max-height: 100vh;
+        padding-top: calc(var(--space-default) + calc(env(safe-area-inset-top, 0) * 3));
+    }
+
     .modal, .modal.small, .modal.medium, .modal.large { 
-        margin-top: calc(var(--space-default) +  calc(env(safe-area-inset-top, 0) * 3));
+        margin-top: 0;
         max-width: 100vw;
-        height: 100vh;
-        /* mobile viewport bug fix */
-        height: -webkit-fill-available;
         transform: translateY(100vh);
         transition: transform 300ms;
         border-top-right-radius: var(--space-half);

--- a/frontends/web/src/components/dialog/dialog.module.css
+++ b/frontends/web/src/components/dialog/dialog.module.css
@@ -108,10 +108,6 @@
     padding: 0;
 }
 
-.contentContainer.padded {
-    padding: var(--space-default);
-}
-
 .content p {
     word-break: break-word;
 }
@@ -219,7 +215,7 @@
     .overlay {
         align-items: stretch;
         max-height: 100vh;
-        padding-top: calc(var(--space-default) + calc(env(safe-area-inset-top, 0) * 3));
+        padding-top: calc(var(--space-default) + env(safe-area-inset-top, 0));
     }
 
     .modal, .modal.small, .modal.medium, .modal.large { 
@@ -235,8 +231,8 @@
       transition: transform 300ms;
       transform: translateY(0);
     }
-
-    .contentContainer.padded {
-        padding: var(--space-half);
+    
+    .contentContainer.slim {
+        padding-bottom: calc(env(safe-area-inset-bottom, 0));
     }
 }


### PR DESCRIPTION
adjusted dialog paddings on ios to maintain usability. Also removed `.padded` class as it's unused.

Before:
<img width="512" height="968" alt="Screenshot_2025-07-20_at_02 27 39" src="https://github.com/user-attachments/assets/406f9c85-2dd6-4dac-a892-c90c22e84a57" />


After (iOS simulator):

<img width="512" height="968" alt="Screenshot 2025-07-20 at 03 33 10" src="https://github.com/user-attachments/assets/b9565121-a4e5-46dd-a160-0176e9faf347" />
<img width="512" height="968" alt="Screenshot 2025-07-20 at 03 33 12" src="https://github.com/user-attachments/assets/62926e9a-570b-4b4c-9d8f-e575671e0b93" />
