### PR TITLE
frontend: fix dialog inner scroll conflict with drag-to-close on mobile

### DIFF
--- a/frontends/web/src/components/dialog/dialog.tsx
+++ b/frontends/web/src/components/dialog/dialog.tsx
@@ -291,6 +291,7 @@ export const DialogScrollContent = ({
 }: DialogScrollContentProps) => {
   return (
     <div
+      data-dialog-scroll-content
       className={style.dialogScrollContent}
       style={{ minHeight }}
     >

--- a/frontends/web/src/components/dialog/mobile-dialog.tsx
+++ b/frontends/web/src/components/dialog/mobile-dialog.tsx
@@ -36,13 +36,27 @@ export const MobileDialog = ({
     if (!contentContainer) {
       return null;
     }
-    if (!(target instanceof HTMLElement)) {
-      return contentContainer;
+
+    let targetElement: Element | null = null;
+    if (target instanceof Element) {
+      targetElement = target;
+    } else if (target instanceof Node) {
+      targetElement = target.parentElement;
     }
-    const scrollContent = target.closest<HTMLElement>('[data-dialog-scroll-content]');
-    if (scrollContent && contentContainer.contains(scrollContent)) {
-      return scrollContent;
+
+    const firstScrollContent = contentContainer.querySelector<HTMLElement>('[data-dialog-scroll-content]');
+    if (!targetElement) {
+      return firstScrollContent ?? contentContainer;
     }
+
+    if (contentContainer.contains(targetElement)) {
+      const scrollContent = targetElement.closest<HTMLElement>('[data-dialog-scroll-content]');
+      if (scrollContent && contentContainer.contains(scrollContent)) {
+        return scrollContent;
+      }
+      return firstScrollContent ?? contentContainer;
+    }
+
     return contentContainer;
   }, [contentContainerRef]);
 

--- a/frontends/web/src/components/dialog/mobile-dialog.tsx
+++ b/frontends/web/src/components/dialog/mobile-dialog.tsx
@@ -29,23 +29,41 @@ export const MobileDialog = ({
   const [dragY, setDragY] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
   const dragStartY = useRef(0);
+  const dragScrollContainerRef = useRef<HTMLElement | null>(null);
+
+  const getTouchScrollContainer = useCallback((target: EventTarget | null) => {
+    const contentContainer = contentContainerRef.current;
+    if (!contentContainer) {
+      return null;
+    }
+    if (!(target instanceof HTMLElement)) {
+      return contentContainer;
+    }
+    const scrollContent = target.closest<HTMLElement>('[data-dialog-scroll-content]');
+    if (scrollContent && contentContainer.contains(scrollContent)) {
+      return scrollContent;
+    }
+    return contentContainer;
+  }, [contentContainerRef]);
 
   const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    dragScrollContainerRef.current = null;
     if (!canClose || status !== 'open') {
       return;
     }
 
-    const contentContainer = contentContainerRef.current;
-    if (contentContainer && contentContainer.scrollTop > 0) {
+    const scrollContainer = getTouchScrollContainer(e.target);
+    if (scrollContainer && scrollContainer.scrollTop > 0) {
       return;
     }
+    dragScrollContainerRef.current = scrollContainer;
 
     const touch = e.touches[0];
     if (touch) {
       dragStartY.current = touch.clientY;
       setIsDragging(true);
     }
-  }, [canClose, status, contentContainerRef]);
+  }, [canClose, status, getTouchScrollContainer]);
 
   useEffect(() => {
     const modal = modalRef.current;
@@ -55,6 +73,14 @@ export const MobileDialog = ({
 
     const handleTouchMove = (e: TouchEvent) => {
       if (!isDragging) {
+        return;
+      }
+
+      const scrollContainer = dragScrollContainerRef.current;
+      if (scrollContainer && scrollContainer.scrollTop > 0) {
+        setIsDragging(false);
+        setDragY(0);
+        dragScrollContainerRef.current = null;
         return;
       }
 
@@ -85,6 +111,7 @@ export const MobileDialog = ({
     }
 
     setIsDragging(false);
+    dragScrollContainerRef.current = null;
     const threshold = window.innerHeight * DRAG_CLOSE_THRESHOLD_PERCENT;
 
     if (dragY > threshold) {
@@ -98,6 +125,7 @@ export const MobileDialog = ({
   const handleTouchCancel = useCallback(() => {
     setIsDragging(false);
     setDragY(0);
+    dragScrollContainerRef.current = null;
   }, []);
 
   const combinedModalClass = `


### PR DESCRIPTION
@thisconnect 

* first commit fixes the issue we discussed, i.e. when swiping down you now scroll to the top and only then trigger drag to close, as expected.
* second commit addresses an edge case, where the drag to close would still trigger when dragging from the far right of the screen even though you would expect it to scroll (because it's outside of the scroll area). It's not really a "natural" area to scroll anyway, so I'm not even sure if I would consider it a bug, but imo like this there is less chance for people experiencing an unexpected close of the dialog. But this can be dropped without affecting the fix in first commit.